### PR TITLE
cmdarg_info so it checks for anything NOT in flags

### DIFF
--- a/cmdarg.sh
+++ b/cmdarg.sh
@@ -102,7 +102,7 @@ function cmdarg_info
     # Sets various flags about your script that are printed during cmdarg_usage
     #
     local flags="header|copyright|footer|author"
-    if [[ "$1" =~ $flags ]]; then
+    if [[ ! "$1" =~ $flags ]]; then
 	echo "cmdarg_info <flag> <value>" >&2
 	echo "Where <flag> is one of $flags" >&2
 	${CMDARG_ERROR_BEHAVIOR} 1


### PR DESCRIPTION
The cmdarg_info function should check whether the input is NOT in flags rather than the other way around. Otherwise it will fail every time when doing one is actually doing the right thing.
