### PR TITLE
Remove all uses of eval

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,5 +1,3 @@
-# Many array expressions are constructed and eval-ed
-disable=SC2016
 # False positive on "CMDARG_ERROR_BEHAVIOR=return"
 disable=SC2209
 # Checking exit code with $? is more of a preference when the script doesn't try to support the errexit shell option

--- a/cmdarg.sh
+++ b/cmdarg.sh
@@ -26,11 +26,9 @@ function cmdarg
     # description : The text description for this option to be used in cmdarg_usage
     #
     # default value : The default value, if any, for the argument
-    # validator : This is passed through eval(), with $OPTARG equal to the current
+    # validator : This is a bash function, invoked with one argument equal to the current
     #             value of the argument in question, and must return non-zero if
-    #             the argument value is invalid. Can be straight bash, but it really
-    #             should be the name of a function. This may be enforced in future versions
-    #             of the library.
+    #             the argument value is invalid.
     local shortopt=${1:0:1}
     local key="$2"
     if [[ "$shortopt" == "h" ]]; then


### PR DESCRIPTION
Beyond being risky, many of these uses of eval were actually vulnerable to shell injection.

Switching all cases to nameref variables improves both security and readability, while only raising the minimum bash version from 4 to 4.3.

A simple example of an exploit against the eval-based version follows
```bash
#!/bin/bash
. cmdarg.sh

declare -a array
declare -A hash
cmdarg 'a:[]' 'array'

cmdarg_parse "$@" || exit 2
```

run like
```sh
./pwn.sh -a '"; whoami; #'
```